### PR TITLE
Require Cabal 1.8+

### DIFF
--- a/IOSpec.cabal
+++ b/IOSpec.cabal
@@ -2,7 +2,7 @@ Name:            IOSpec
 Version:         0.3.1.1
 License:         BSD3
 License-file:    LICENSE
-Cabal-Version:   >= 1.6
+Cabal-Version:   >= 1.8
 Author:          Wouter Swierstra,
                  Yusaku Hashimoto,
                  Nikolay Amiantov,


### PR DESCRIPTION
Fixes the following warning:

```
Warning: IOSpec.cabal:55:41: version operators used. To use version operators
the package needs to specify at least 'cabal-version: >= 1.8'.
```