### PR TITLE
Support mtl 2.3

### DIFF
--- a/src/Test/IOSpec/VirtualMachine.hs
+++ b/src/Test/IOSpec/VirtualMachine.hs
@@ -43,7 +43,7 @@ import Data.List
 import qualified Data.Stream as Stream
 import Test.IOSpec.Types
 import Test.QuickCheck
-import Control.Monad (ap)
+import Control.Monad (liftM, ap)
 
 type Data         = Dynamic
 type Loc          = Int


### PR DESCRIPTION
Control.Monad.State no longer reëxports Control.Monad

This change is enough to support building with GHC 9.6.